### PR TITLE
use the rmx-prod-uploads CI context for the deploy key

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-version: 2
+version: 2.1
 jobs:
   build:
     docker:
@@ -15,3 +15,9 @@ jobs:
     - run: make test
     - run: ci/ensure-gcloud-creds
     - run: ci/upload_web
+
+workflows:
+  build:
+    jobs:
+      - build:
+          context: rmx-prod-uploads

--- a/ci/ensure-gcloud-creds
+++ b/ci/ensure-gcloud-creds
@@ -18,12 +18,10 @@ fi
 #
 # Put the output of the second command in the relevant environment var.
 set +x
-echo $RMX_DEPLOY_KEY | $B64_DECODE > ~/deploy_key.json
+echo $RMX_PROD_DEPLOY_KEY | $B64_DECODE > ~/deploy_key.json
 set -x
 
-# staging
 # activate service account
 gcloud --project rmx-prod auth activate-service-account --key-file ~/deploy_key.json
 
 gcloud auth list
-gcloud -q auth configure-docker


### PR DESCRIPTION
sibling to https://github.com/remixlabs/groovebox/pull/166, etc.