### PR TITLE
fix caml_callback

### DIFF
--- a/src/initruntime.c
+++ b/src/initruntime.c
@@ -67,6 +67,7 @@ void wasicaml_main(char **argv) {
     value *fp = Caml_state->_extern_sp;
     wasicaml_init();
     letrec_main((value *) -1, extra_args, codeptr, fp);
+    Caml_state->_extern_sp = fp;
 }
 
 int main(int argc, char **argv) {


### PR DESCRIPTION
Fixes that you can register callbacks in the OCaml program, and then use them in the remainder of the app from the host environment.