### PR TITLE
fix tracing globals

### DIFF
--- a/src/wasicaml/wc_emit.ml
+++ b/src/wasicaml/wc_emit.ml
@@ -3173,9 +3173,9 @@ let rec emit_instr gpad fpad instr =
     | Walloc arg ->
         copy fpad arg.src arg.dest (Some arg.descr)
     | Wenv arg ->
-        push_env
-        @ load_offset (4 * arg.field)
-        @ pop_to_local "accu"
+        ( push_env
+          @ load_offset (4 * arg.field)
+        ) |> pop_to fpad arg.dest RValue None
     | Wcopyenv arg ->
         push_env
         @ add_offset (4 * arg.offset)
@@ -3198,7 +3198,7 @@ let rec emit_instr gpad fpad instr =
         ]
          *)
         push_global offset
-        @ pop_to_local "accu"
+        |> pop_to fpad arg.dest RValue None
     | Wunary arg ->
         emit_unary gpad fpad arg.op arg.src1 arg.dest
     | Wunaryeffect arg ->

--- a/test/t062_fields7.ml
+++ b/test/t062_fields7.ml
@@ -1,0 +1,10 @@
+let next = ref 0
+
+let f() =
+  let k = !next in
+  incr next;
+  Testprint.int "k" k;
+  Testprint.int "next" !next
+
+let () =
+  f()

--- a/test/t062_fields8.ml
+++ b/test/t062_fields8.ml
@@ -1,0 +1,13 @@
+let next = ref 0
+
+let g() =
+  incr next
+
+let f() =
+  let k = !next in
+  g();
+  Testprint.int "k" k;
+  Testprint.int "next" !next
+
+let () =
+  f()

--- a/test/t062_fields9.ml
+++ b/test/t062_fields9.ml
@@ -1,0 +1,12 @@
+let current = ref (fun () -> Testprint.string "fun" "p1")
+
+let f() =
+  current := (fun () -> Testprint.string "fun" "p2");
+  let h = !current in
+  current := (fun () -> Testprint.string "fun" "p3");
+  h();
+  !current()
+
+let () =
+  f()
+


### PR DESCRIPTION
WasiCaml tries to figure out which functions are actually called by tracing the initialization of global values. The problem is that there is no super-clear way of distinguishing between blocks representing modules and blocks representing records. Fields in the latter can be mutable, however, and this may lead to subtle bugs. In particular, accesses to a mutable global variable
```
let x = ref (fun () -> ...)
```
look identical to accesses of a global function
```
struct
  let f = (fun () -> ...)
end
```
(get the global -> access field 0), but only the latter is constant.

The problem is tackled by two measures:
 - If instructions are found that can have effects, we cannot exclude that the effects target a variable like `x`. We have to drop any information about how to get to `x` via a global.
 - also, we exploit some knowledge about the structure of top-level modules, and disregard any accesses to globals that do not fit to this structure