### PR TITLE
add option -no-quick-exceptions

### DIFF
--- a/test/run
+++ b/test/run
@@ -54,6 +54,9 @@ while [ $# -gt 0 ]; do
         -eh)
             args="$args -enable-exception-handling"
             shift ;;
+	-no-quick)
+	    args="$args -no-quick-exceptions"
+	    shift ;;
         -compact-code)
             args="$args -compact-code $2"
             shift 2 ;;


### PR DESCRIPTION
The effect of this option is that the result value 0 can no longer be used to indicate that a function has an exception result.

Upside: it is possible to get backtraces from the JS caller

Downside: much slower
