### PR TITLE
fix main splitter

### DIFF
--- a/src/wasicaml/wc_control.ml
+++ b/src/wasicaml/wc_control.ml
@@ -413,6 +413,8 @@ let split_main_function cfg =
               Array.iter exclude qlist;
           | I.Kpushtrap lab ->
               set_depth (!d-4) lab
+          | I.Kpush_retaddr lab ->
+              exclude lab
           | _ ->
               ()
       done;


### PR DESCRIPTION
fix: do not split the main functions directly after returning from a call