### PR TITLE
upgrade to wasi-sdk-25

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,8 @@ default: setup configure build install build2 install2
 
 setup: setup-git setup-downloads setup-bin setup-js
 
+setup-dev: setup-downloads setup-bin setup-js
+
 setup-downloads:
 	./install_wasi-sdk
 	if [ -n "$(WASI_LIBC_BRANCH)" ]; then $(MAKE) build-wasi-libc; fi

--- a/bin-template/wasi_cc
+++ b/bin-template/wasi_cc
@@ -48,7 +48,7 @@ if [ $noexe -eq 0 ]; then
     if [ $eh -gt 0 ]; then
         initobjs="$root/lib/initwasi_eh.o $root/lib/initwasi_eh_helpers.o"
     fi
-    init="$initobjs -Wl,--stack-first -lwasi-emulated-process-clocks"
+    init="$initobjs -Wl,--stack-first -Wl,--initial-heap=67108864 -Wl,-z,stack-size=1048576 -lwasi-emulated-process-clocks"
     case "$out" in
         *.wasm)
             genwrapper=0
@@ -56,10 +56,11 @@ if [ $noexe -eq 0 ]; then
     esac
 fi
 
-"$root"/lib/wasi-sdk/bin/clang --sysroot="$root"/lib/wasi-sdk/share/wasi-sysroot $init -D_WASI_EMULATED_PROCESS_CLOCKS -Wno-unused-command-line-argument "$@"
+"$root"/lib/wasi-sdk/bin/clang --target=wasm32-wasip1 --sysroot="$root"/lib/wasi-sdk/share/wasi-sysroot $init -D_WASI_EMULATED_PROCESS_CLOCKS -Wno-unused-command-line-argument "$@"
 
 if [ $genwrapper -gt 0 -a -f "$out" ]; then
     wasm=`mktemp tmp.XXXXXX`
+    #cp "$out" "$out.wasm"
     mv "$out" "$wasm"
     len=`cat "$wasm" | wc -c`
     cat %PREFIX%/bin/wasi_preamble > "$out"

--- a/install_wasi-sdk
+++ b/install_wasi-sdk
@@ -2,8 +2,10 @@
 
 set -e
 
-major="19"
+major="25"
 minor="0"
+
+arch="$(uname -m)"
 
 case "$(uname)" in
      Darwin)
@@ -18,8 +20,8 @@ case "$(uname)" in
          ;;
 esac
 
-base="wasi-sdk-${major}.${minor}"
-file="${base}-${variant}.tar.gz"
+base="wasi-sdk-${major}.${minor}-${arch}-${variant}"
+file="${base}.tar.gz"
 url="https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-${major}/$file"
 
 if [ ! -f "$file" ]; then

--- a/src/wasicaml/wc_emit.ml
+++ b/src/wasicaml/wc_emit.ml
@@ -2596,17 +2596,16 @@ let grab fpad num =
                 L [ K "local.get"; ID "fp" ];
               ]
               @ call_restart_helper()
-              @ pop_to_fp fpad
-              @ [ L [ K "local.set"; ID "extra_args" ];
-
-                  (* codeptr &= ~1 - I think this is not needed *)
-                  (*
-                  L [ K "local.get"; ID "codeptr" ];
-                  L [ K "i32.const"; N (I32 0xffff_fffel) ];
-                  L [ K "i32.and" ];
-                  L [ K "local.set"; ID "codeptr" ];
-                   *)
+              @ [ L [ K "local.set"; ID "fp" ];
+                  L [ K "local.set"; ID "extra_args" ];
                 ]
+              @ (* pop_to_fp fpad *)
+                ( if fpad.maxdepth = 0 then
+                    []
+                  else
+                    [ L [ K "local.get"; ID "fp" ] ]
+                    @ set_bp_1 fpad
+                )
             )
         ];
 


### PR DESCRIPTION
Upgrades wasi-sdk to 25 (llvm-19). We cannot go beyond this because of https://github.com/llvm/llvm-project/issues/195639.

(The bug appears in ocaml/runtime/array.c line 298.)
